### PR TITLE
Add Kellokortti API examples

### DIFF
--- a/csharp/get_person_kellokortti.cs
+++ b/csharp/get_person_kellokortti.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+public class KellokorttiClient
+{
+    private static readonly HttpClient client = new HttpClient();
+    private readonly string apiUrl;
+    private readonly string username;
+    private readonly string password;
+
+    public KellokorttiClient()
+    {
+        apiUrl = Environment.GetEnvironmentVariable("KK_API_URL") ?? "https://api.kellokortti.fi/api";
+        username = Environment.GetEnvironmentVariable("KK_USERNAME");
+        password = Environment.GetEnvironmentVariable("KK_PASSWORD");
+    }
+
+    public async Task<dynamic> GetPersonAsync(string personId)
+    {
+        var url = $"{apiUrl}/api/v1/person/{personId}";
+        var credentials = Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes($"{username}:{password}"));
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+        var response = await client.GetAsync(url);
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync();
+        return JsonConvert.DeserializeObject<dynamic>(content);
+    }
+}
+
+public class Program
+{
+    public static async Task Main(string[] args)
+    {
+        var client = new KellokorttiClient();
+        var personId = Environment.GetEnvironmentVariable("KK_PERSON_ID") ?? "testuser";
+        var person = await client.GetPersonAsync(personId);
+        Console.WriteLine(JsonConvert.SerializeObject(person));
+    }
+}

--- a/csharp/readme.md
+++ b/csharp/readme.md
@@ -41,3 +41,18 @@ The `CreateCustomerUrl` method creates the URL for fetching customers.
 The `ApiResponse` class represents the API response.
 
 The `Program` class contains the `Main` method, which creates a new `LemonsoftClient`, logs into the Lemonsoft system, and fetches all customers from the system.
+
+## Kellokortti Example
+
+The `get_person_kellokortti.cs` file demonstrates using Basic authentication with the Kellokortti API. Set these environment variables:
+
+- `KK_API_URL` (defaults to `https://api.kellokortti.fi/api`)
+- `KK_USERNAME`
+- `KK_PASSWORD`
+- `KK_PERSON_ID` (optional)
+
+Compile and run:
+
+```bash
+dotnet run get_person_kellokortti.cs
+```

--- a/php/get_person_kellokortti.php
+++ b/php/get_person_kellokortti.php
@@ -1,0 +1,23 @@
+<?php
+function get_kellokortti_person($person_id) {
+    $apiUrl = getenv('KK_API_URL') ?: 'https://api.kellokortti.fi/api';
+    $username = getenv('KK_USERNAME');
+    $password = getenv('KK_PASSWORD');
+    if (!$username || !$password) {
+        throw new Exception('KK_USERNAME and KK_PASSWORD must be set');
+    }
+    $url = "$apiUrl/api/v1/person/$person_id";
+    $opts = array(
+        'http' => array(
+            'method' => 'GET',
+            'header' => 'Authorization: Basic ' . base64_encode("$username:$password")
+        )
+    );
+    $context = stream_context_create($opts);
+    $response = file_get_contents($url, false, $context);
+    return json_decode($response, true);
+}
+
+$pid = getenv('KK_PERSON_ID') ?: 'testuser';
+print_r(get_kellokortti_person($pid));
+?>

--- a/php/readme.md
+++ b/php/readme.md
@@ -41,3 +41,21 @@ The script will print the session ID if the login is successful, and then it wil
 
 Please note that this README assumes you have PHP and Composer installed on your machine. If you don't, you can download PHP from [php.net](https://www.php.net/downloads) and Composer from [getcomposer.org](https://getcomposer.org/download/).
 
+
+## Kellokortti Example
+
+`get_person_kellokortti.php` shows how to read a person from the Kellokortti API.
+Set these environment variables before running:
+
+```
+KK_API_URL=https://api.kellokortti.fi/api
+KK_USERNAME=your_username
+KK_PASSWORD=your_password
+KK_PERSON_ID=identifier    # optional
+```
+
+Run:
+
+```bash
+php get_person_kellokortti.php
+```

--- a/python/get_person_kellokortti.py
+++ b/python/get_person_kellokortti.py
@@ -1,0 +1,22 @@
+import os
+import requests
+from requests.auth import HTTPBasicAuth
+
+
+def get_person(person_id: str):
+    """Fetch a person from the Kellokortti API using Basic authentication."""
+    api_url = os.environ.get("KK_API_URL", "https://api.kellokortti.fi/api")
+    username = os.environ.get("KK_USERNAME")
+    password = os.environ.get("KK_PASSWORD")
+    if not username or not password:
+        raise ValueError("KK_USERNAME and KK_PASSWORD must be set")
+
+    url = f"{api_url}/api/v1/person/{person_id}"
+    response = requests.get(url, auth=HTTPBasicAuth(username, password))
+    response.raise_for_status()
+    return response.json()
+
+
+if __name__ == "__main__":
+    pid = os.environ.get("KK_PERSON_ID", "testuser")
+    print(get_person(pid))

--- a/python/readme.md
+++ b/python/readme.md
@@ -28,3 +28,20 @@ You can set these variables in your shell, or you can use a `.env` file if you'r
 To run the script, navigate to the project directory in your terminal and run `python get_customers.py`.
 
 The script will print the session ID if the login is successful, and then it will print the list of customers.
+
+## Kellokortti Example
+
+The `get_person_kellokortti.py` script demonstrates how to fetch a person from the Kellokortti API using HTTP Basic authentication.
+
+Set the following environment variables:
+
+- `KK_API_URL` (defaults to `https://api.kellokortti.fi/api` if not set)
+- `KK_USERNAME`
+- `KK_PASSWORD`
+- `KK_PERSON_ID` (optional, ID of the person to fetch)
+
+Run the script with:
+
+```bash
+python get_person_kellokortti.py
+```


### PR DESCRIPTION
## Summary
- add Basic auth example scripts for the Kellokortti API in C#, PHP and Python
- document new scripts in respective READMEs

## Testing
- `python -m py_compile python/*.py`
- `php -l php/get_customers.php` *(fails: command not found)*
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852603727a083259f4e272b57673992